### PR TITLE
Handle undefined options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bennord-awesome-cordova-plugins",
-  "version": "5.45.1",
+  "version": "5.45.2",
   "description": "Native plugin wrappers for Cordova and Ionic with TypeScript, ES6+, Promise and Observable support",
   "homepage": "https://awesome-cordova-plugins.com",
   "author": "Daniel Sogl <me@danielsogl.com> (https://danielsogl.com). Fork by bennord.",

--- a/src/@awesome-cordova-plugins/plugins/in-app-browser/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/in-app-browser/index.ts
@@ -194,6 +194,7 @@ export class InAppBrowserObject {
     try {
       if (options && typeof options !== 'string') {
         options = Object.keys(options)
+          .filter((key) => (options as InAppBrowserOptions)[key] !== undefined)
           .map((key: string) => {
             let value = (options as InAppBrowserOptions)[key];
             if (typeof value !== 'string') {


### PR DESCRIPTION
- fix unhandled exception when passing options with a key set to equal `undefined`.
- bump version to 5.45.2